### PR TITLE
Potential fix for code scanning alert no. 3: Disabled TLS certificate check

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -24,7 +24,7 @@ func init() {
 			return http.ErrUseLastResponse
 		},
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{}, // Use system's default trusted CA pool
 		},
 		Timeout: 10 * time.Second,
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Iandenh/overleash/security/code-scanning/3](https://github.com/Iandenh/overleash/security/code-scanning/3)

To fix the issue, remove the `InsecureSkipVerify: true` setting from the `tls.Config` object on line 27. Instead, configure valid certificates for the client to use when connecting to the server. If you need to trust custom certificates (e.g., self-signed certificates), you can use `tls.Config{RootCAs}` to specify a pool of trusted certificates explicitly rather than disabling verification.

This requires:
1. Ensuring that the server's certificates are valid and trusted.
2. Configuring the `tls.Config` object correctly using `RootCAs` or leaving it default (to use the system's trusted CA pool).

The changes will be applied in the `proxy/proxy.go` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
