### PR TITLE
Potential fix for code scanning alert no. 2: Disabled TLS certificate check

### DIFF
--- a/overleash/client.go
+++ b/overleash/client.go
@@ -46,7 +46,7 @@ func newClient(upstream string, interval int) *overleashclient {
 				return http.ErrUseLastResponse
 			},
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig: &tls.Config{},
 			},
 		},
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Iandenh/overleash/security/code-scanning/2](https://github.com/Iandenh/overleash/security/code-scanning/2)

To resolve this issue, the `InsecureSkipVerify: true` setting should be removed entirely unless there is a valid reason for disabling certificate verification (e.g., testing). In cases where self-signed certificates are used, the proper approach is to load the certificate into a `tls.Config` object and use it for TLS verification. This fix ensures the application communicates securely with its upstream server, protecting against MITM attacks.

Specifically:
1. Replace `InsecureSkipVerify: true` with proper certificate verification. If custom certificates are needed, load them using the `x509` standard library and configure the `tls.Config.RootCAs` field.
2. Ensure the fix does not modify existing functionality other than securing TLS communication.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
